### PR TITLE
Add quickstart links for pre-summit trainings

### DIFF
--- a/docs/virtual-meetings.md
+++ b/docs/virtual-meetings.md
@@ -8,17 +8,16 @@ Please join us for our pre-Summit training events:
 
 - [Brainstorming Sheets](https://drive.google.com/drive/folders/1wUEIIDvpyfN7ZSsaT-0M59V2Ph07TT8c?usp=drive_link) - You may keep adding ideas until August 19th. Please do not delete or type over anyone else’s idea.
 
-**Navigating CyVerse and Github: A Gateway to Advanced Computation for Science** - Wednesday, September 3rd, 1-3 pm MT 
+**Navigating CyVerse and Github: A Gateway to Advanced Computation for Science** - Wednesday, September 3rd, 1-3 pm MT
 
-- [ESIIL's Cloud Computing Quickstart Guide](https://cu-esiil.github.io/home/quickstart/cloud/)
-  
+- [Main document: ESIIL's Cloud Computing Quickstart Guide](https://cu-esiil.github.io/home/quickstart/cloud/)
 - Please set up a [GitHub account](https://github.com/) and a [CyVerse account](https://user.cyverse.org/signup) and let us know your usernames by completing this [quick form](https://docs.google.com/forms/d/e/1FAIpQLSccCdVt3RmCvHXBRrg1n8gYKiw5QUuOMezvhGs5fr9CGkcTjA/viewform?usp=dialog).
-  
 - [View Recording](https://o365coloradoedu.sharepoint.com/:v:/s/CIRES-ESIIL/EfEseb74YPhAvfYF722zOOIB4uwmexZqyqHe6F2jDQPYVQ?e=vhDP3G)
   
-**Creative Data Exploration in the Cloud with AI: Innovating with Open Science** - Tuesday, September 9th, 1-3 pm MT 
+**Creative Data Exploration in the Cloud with AI: Innovating with Open Science** - Tuesday, September 9th, 1-3 pm MT
 
-Haven't received a calendar invite? Please email esiil@colorado.edu to get the Zoom link.
+- [Main document: ESIIL's Python Quickstart Guide](https://cu-esiil.github.io/home/quickstart/python/)
+- Haven't received a calendar invite? Please email esiil@colorado.edu to get the Zoom link.
 
 **Recordings will be posted here after each training.**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,11 +17,13 @@ nav:
        - Overview: virtual-meetings.md
        - Science Jam: science_jam.md
        - CyVerse and Github:
+           - Cloud Computing Quickstart Guide: https://cu-esiil.github.io/home/quickstart/cloud/
            - Markdown: resources/markdown_basics.md
            - Github: resources/github_basics.md
            - Cyverse: resources/cyverse_basics.md
            - Cyverse hacks: resources/cyverse_hacks.md
-       - Data Exploration in the Cloud: 
+       - Data Exploration in the Cloud:
+           - Python Quickstart Guide: https://cu-esiil.github.io/home/quickstart/python/
            - Startup procedure: resources/cyverse_startup.md
            - Move and Save data: data-library/move-data-to-instance.md
            - Stream data: data-library/stac_mount_save.md


### PR DESCRIPTION
## Summary
- link cloud and python quickstart guides at top of Pre-Summit training sections
- expose quickstart guides in mkdocs navigation for intro-to-cloud and data-exploration sessions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0a7befb5083259fac4adbc73fb372