### PR TITLE
Improve summit buttons readability

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,19 +1,24 @@
 .summit-buttons {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 1rem;
-  justify-content: center;
+  width: 100%;
   margin: 1rem 0;
 }
 
 .summit-button {
-  display: inline-block;
-  padding: 0.75rem 1.5rem;
-  background-color: #1565c0;
-  color: #fff;
+  display: block;
+  padding: 1rem 1.5rem;
+  background-color: #e0e0e0;
+  color: #1565c0;
+  border: 1px solid #1565c0;
   border-radius: 4px;
   text-decoration: none;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  font-size: 1.25rem;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
 }
 
 .summit-button:hover {


### PR DESCRIPTION
## Summary
- Restyle summit buttons with gray background, blue text, and larger font
- Make summit buttons span full width responsively

## Testing
- `mkdocs build | tail -n 2`


------
https://chatgpt.com/codex/tasks/task_e_68c0ad9a78bc83259f0b7501f8fe5109