### PR TITLE
Add group repo buttons

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -217,3 +217,26 @@ Boulder has an extensive system of city walking/biking paths; [maps can be found
 
 
 *This event is hosted by ESIIL and funded by the National Science Foundation (via award # DBI-2153040), and subject to the NSF’s terms and conditions.
+
+## Group Repos
+
+<div class="group-repos">
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 1</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 2</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 3</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 4</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 5</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 6</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 7</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 8</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 9</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 10</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 11</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 12</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 13</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 14</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 15</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 16</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 17</a>
+  <a class="group-repo-button" href="https://github.com/CU-ESIIL/Innovation-Summit-2024__2_Species-interactions-under-climate-change">Group Repo 18</a>
+</div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -25,3 +25,28 @@
   transform: translateY(-3px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
+
+.group-repos {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin: 2rem 0;
+}
+
+.group-repo-button {
+  display: block;
+  padding: 1rem 1.5rem;
+  background-color: #e0e0e0;
+  color: #1565c0;
+  border: 1px solid #1565c0;
+  border-radius: 4px;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  text-align: center;
+}
+
+.group-repo-button:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+


### PR DESCRIPTION
## Summary
- Add 'Group Repos' section to home page with 18 placeholder buttons
- Style new buttons with grid layout and hover animation

## Testing
- `mkdocs build` *(warnings: deprecation messages)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dfa720348325bf8206e651d3e7a9